### PR TITLE
Add admin route and electron dev setup

### DIFF
--- a/client/src/Admin.tsx
+++ b/client/src/Admin.tsx
@@ -1,0 +1,8 @@
+export default function Admin() {
+  return (
+    <div>
+      <h1>관리자 페이지</h1>
+      <p>Electron 앱 기본 경로입니다.</p>
+    </div>
+  )
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
 import { Link, Route, Routes } from 'react-router-dom'
+import Admin from './Admin'
 import { useCounterStore } from './store'
 
 function Home() {
@@ -25,6 +26,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/about" element={<About />} />
+        <Route path="/admin" element={<Admin />} />
       </Routes>
     </div>
   )

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "workspaces": ["client", "server"],
   "scripts": {
-    "lint": "npm --workspaces run lint"
+    "lint": "npm --workspaces run lint",
+    "dev": "concurrently \"npm run dev -w client\" \"npm run dev -w server\""
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.0"
   }
 }

--- a/server/main.js
+++ b/server/main.js
@@ -1,0 +1,30 @@
+const { app, BrowserWindow } = require('electron');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      contextIsolation: true,
+    },
+  });
+
+  win.loadURL('http://localhost:5173/admin');
+}
+
+app.whenReady().then(() => {
+  require('./index.js');
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
+    "dev": "electron --no-sandbox main.js",
     "test": "echo \"No tests\"",
     "lint": "eslint . --config .eslintrc.cjs"
   },
@@ -16,6 +17,7 @@
     "express": "^5.1.0"
   },
   "devDependencies": {
+    "electron": "^30.5.1",
     "eslint": "^8.57.1"
   }
 }


### PR DESCRIPTION
## Summary
- client에 `/admin` 라우트 페이지 추가
- Electron 앱을 실행하는 `server/main.js` 생성
- 서버 dev 스크립트 수정(`--no-sandbox` 옵션 포함)
- 루트에서 클라이언트와 서버를 동시에 실행할 `npm run dev` 스크립트 추가

## Testing
- `npm run lint`
- `npm test -w server`
- `npm run dev` *(Electron 실행 실패 - root 권한 오류 확인)*

------
https://chatgpt.com/codex/tasks/task_e_687205d0ee10833086304e86c1a49619