### PR TITLE
서버와 Electron 동기화

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,12 +1,50 @@
 import express from 'express';
+import type { Server } from 'http';
 
 const app = express();
-const port = process.env.PORT || 3000;
+const port = Number(process.env.PORT) || 3000;
+
+let server: Server | null = null;
 
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.listen(port, () => {
-  console.log(`Server listening on http://localhost:${port}`);
-});
+export function startServer(): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    if (server) {
+      resolve(server);
+      return;
+    }
+
+    server = app
+      .listen(port, () => {
+        console.log(`Server listening on http://localhost:${port}`);
+        resolve(server!);
+      })
+      .on('error', (err) => {
+        reject(err);
+      });
+  });
+}
+
+export function stopServer(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!server) {
+      resolve();
+      return;
+    }
+
+    server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      console.log('Server stopped');
+      server = null;
+      resolve();
+    });
+  });
+}
+
+export { app };

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow } from 'electron';
-import './index';
+import { startServer, stopServer } from './index';
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -13,7 +13,8 @@ function createWindow() {
   win.loadURL('http://localhost:5173/admin');
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  await startServer();
   createWindow();
 
   app.on('activate', () => {
@@ -23,8 +24,13 @@ app.whenReady().then(() => {
   });
 });
 
-app.on('window-all-closed', () => {
+app.on('window-all-closed', async () => {
   if (process.platform !== 'darwin') {
+    await stopServer();
     app.quit();
   }
+});
+
+app.on('before-quit', () => {
+  void stopServer();
 });


### PR DESCRIPTION
## 요약
- Electron 실행 시 Express 서버를 시작하고 종료 시 서버도 함께 종료하도록 수정했습니다.
- `index.ts`에 서버 시작/종료 함수를 추가하고 `main.ts`에서 해당 함수를 호출합니다.

## 테스트
- `npm run lint` 실행 결과 경고 1개 발생 (오류 없음)【1e6ba1†L1-L13】
- `npm test` 실행 결과 테스트 없음 메시지 확인【0658da†L1-L8】

------
https://chatgpt.com/codex/tasks/task_e_68727f5d98a08330b61225708976e785