### PR TITLE
Centralize query hooks

### DIFF
--- a/client/app/hooks/useHealth.ts
+++ b/client/app/hooks/useHealth.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { QUERY_KEYS } from "~/queryKeys";
+
+export function useHealth() {
+  return useQuery({
+    queryKey: QUERY_KEYS.health,
+    queryFn: async () => {
+      const res = await fetch("http://localhost:3000/health");
+      return (await res.json()) as { status: string };
+    },
+  });
+}

--- a/client/app/queryKeys.ts
+++ b/client/app/queryKeys.ts
@@ -1,0 +1,3 @@
+export const QUERY_KEYS = {
+  health: ["health"] as const,
+} as const;

--- a/client/app/routes/_index.tsx
+++ b/client/app/routes/_index.tsx
@@ -1,16 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
 import { Button } from "~/components/ui/button";
+import { useHealth } from "~/hooks/useHealth";
 import { useCounterStore } from "../store";
-
-function useHealth() {
-  return useQuery({
-    queryKey: ["health"],
-    queryFn: async () => {
-      const res = await fetch("http://localhost:3000/health");
-      return (await res.json()) as { status: string };
-    },
-  });
-}
 
 export default function Home() {
   const { count, inc } = useCounterStore();


### PR DESCRIPTION
## 요약
- tanstack query 훅을 hooks 폴더에 분리
- query key를 한 파일에 정의
- 홈 페이지에서 분리된 훅 사용

## 테스트
- `npm run lint` (client 패키지에서 실행했으나 스크립트 없음)
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68727fb2eb7c83309d57bdee058e57f6