### PR TITLE
lint 경고 수정

### DIFF
--- a/client/app/components/ui/button-variants.ts
+++ b/client/app/components/ui/button-variants.ts
@@ -1,0 +1,30 @@
+import { cva } from "class-variance-authority";
+
+/**
+ * `buttonVariants`는 다양한 버튼 스타일을 정의합니다.
+ */
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);

--- a/client/app/components/ui/button.tsx
+++ b/client/app/components/ui/button.tsx
@@ -1,34 +1,9 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
+import { buttonVariants } from "./button-variants";
 
 import { cn } from "~/lib/utils";
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -50,4 +25,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 );
 Button.displayName = "Button";
 
-export { Button, buttonVariants };
+export { Button };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,13 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    ignores: ["dist", "node_modules", "eslint.config.js"],
+    ignores: [
+      "dist",
+      "node_modules",
+      "eslint.config.js",
+      "client/.react-router",
+      "server/dist",
+    ],
   },
   {
     files: ["**/*.{js,ts,tsx}"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "gilton-system",
   "private": true,
+  "type": "module",
   "workspaces": [
     "client",
     "server"

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -5,5 +5,6 @@
     "noEmit": true,
     "target": "ES2022"
   },
-  "include": ["client/**/*", "server/**/*"]
+  "include": ["client/**/*", "server/**/*"],
+  "exclude": ["client/.react-router", "server/dist"]
 }


### PR DESCRIPTION
## 변경 내용
- `Button` 컴포넌트 파일에서 `buttonVariants` 상수를 분리하여 별도 파일(`button-variants.ts`)로 이동
- 이에 맞춰 `button.tsx`에서 불필요한 코드 제거 및 새로운 모듈을 임포트

## 테스트
- `npm run lint` 실행하여 경고가 사라짐을 확인

------
https://chatgpt.com/codex/tasks/task_e_687281305f008330b930f69bded1d130