### PR TITLE
홈 화면 프로필 관리 기능 추가

### DIFF
--- a/client/app/lib/api.ts
+++ b/client/app/lib/api.ts
@@ -1,0 +1,21 @@
+import type { Profile } from "../store";
+
+const API_BASE = "http://localhost:3000";
+
+export async function fetchProfiles(): Promise<Profile[]> {
+  const res = await fetch(`${API_BASE}/profiles`);
+  if (!res.ok) throw new Error("failed to fetch");
+  return (await res.json()) as Profile[];
+}
+
+export async function postProfile(
+  profile: Omit<Profile, "id">,
+): Promise<Profile> {
+  const res = await fetch(`${API_BASE}/profiles`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(profile),
+  });
+  if (!res.ok) throw new Error("failed to create");
+  return (await res.json()) as Profile;
+}

--- a/client/app/lib/api.ts
+++ b/client/app/lib/api.ts
@@ -1,21 +1,18 @@
+import axios from "axios";
 import type { Profile } from "../store";
 
-const API_BASE = "http://localhost:3000";
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE ?? "http://localhost:3000",
+});
 
 export async function fetchProfiles(): Promise<Profile[]> {
-  const res = await fetch(`${API_BASE}/profiles`);
-  if (!res.ok) throw new Error("failed to fetch");
-  return (await res.json()) as Profile[];
+  const res = await apiClient.get<Profile[]>("/profiles");
+  return res.data;
 }
 
 export async function postProfile(
   profile: Omit<Profile, "id">,
 ): Promise<Profile> {
-  const res = await fetch(`${API_BASE}/profiles`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(profile),
-  });
-  if (!res.ok) throw new Error("failed to create");
-  return (await res.json()) as Profile;
+  const res = await apiClient.post<Profile>("/profiles", profile);
+  return res.data;
 }

--- a/client/app/routes/_index.tsx
+++ b/client/app/routes/_index.tsx
@@ -1,26 +1,64 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import { Button } from "~/components/ui/button";
-import { useCounterStore } from "../store";
-
-function useHealth() {
-  return useQuery({
-    queryKey: ["health"],
-    queryFn: async () => {
-      const res = await fetch("http://localhost:3000/health");
-      return (await res.json()) as { status: string };
-    },
-  });
-}
+import { useProfileStore, type Profile } from "../store";
+import { fetchProfiles, postProfile } from "../lib/api";
 
 export default function Home() {
-  const { count, inc } = useCounterStore();
-  const { data } = useHealth();
+  const { setProfile } = useProfileStore();
+  const queryClient = useQueryClient();
+  const { data: profiles } = useQuery({
+    queryKey: ["profiles"],
+    queryFn: fetchProfiles,
+  });
+
+  const mutation = useMutation({
+    mutationFn: postProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["profiles"] });
+    },
+  });
+
+  const [name, setName] = useState("");
+  const [role, setRole] = useState("세션 사용자");
+
   return (
-    <div>
-      <h1>홈 페이지</h1>
-      <p>카운트: {count}</p>
-      <Button onClick={inc}>증가</Button>
-      <pre>{data ? JSON.stringify(data) : "로딩 중..."}</pre>
+    <div className="space-y-4">
+      <h1>프로필 선택</h1>
+      <ul className="space-y-2">
+        {profiles?.map((p: Profile) => (
+          <li key={p.id}>
+            <Button onClick={() => setProfile(p)}>{p.name} ({p.role})</Button>
+          </li>
+        ))}
+      </ul>
+
+      <h2 className="mt-4">새 프로필 생성</h2>
+      <div className="flex gap-2">
+        <input
+          className="border p-2"
+          placeholder="이름"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <select
+          className="border p-2"
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+        >
+          <option value="세션 사용자">세션 사용자</option>
+          <option value="인도자">인도자</option>
+          <option value="목사님">목사님</option>
+        </select>
+        <Button
+          onClick={() => {
+            mutation.mutate({ name, role });
+            setName("");
+          }}
+        >
+          생성
+        </Button>
+      </div>
     </div>
   );
 }

--- a/client/app/store.ts
+++ b/client/app/store.ts
@@ -9,3 +9,21 @@ export const useCounterStore = create<CounterState>((set) => ({
   count: 0,
   inc: () => set((state) => ({ count: state.count + 1 })),
 }));
+
+export interface Profile {
+  id: string;
+  name: string;
+  role: string;
+  icon?: string;
+  commands?: string[];
+}
+
+interface ProfileState {
+  profile?: Profile;
+  setProfile: (profile: Profile) => void;
+}
+
+export const useProfileStore = create<ProfileState>((set) => ({
+  profile: undefined,
+  setProfile: (profile) => set({ profile }),
+}));

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.83.0",
+    "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@react-router/node": "^7.5.3",
         "@tanstack/react-query": "^5.83.0",
+        "axios": "^1.10.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "isbot": "^5",
@@ -3942,6 +3943,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -4004,6 +4011,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-dead-code-elimination": {
@@ -4427,6 +4445,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -4779,6 +4809,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5018,7 +5057,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5599,6 +5637,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -5630,6 +5688,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -6075,7 +6170,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7677,6 +7771,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4539,6 +4539,19 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -7240,6 +7253,15 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -10311,6 +10333,7 @@
     "server": {
       "version": "1.0.0",
       "dependencies": {
+        "cors": "^2.8.5",
         "express": "^5.1.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3364,6 +3364,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -10437,6 +10447,7 @@
         "express": "^5.1.0"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/express": "^4.17.21",
         "@types/node": "^20.12.5",
         "@typescript-eslint/eslint-plugin": "^8.36.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,43 +1,41 @@
-import express from 'express';
-import type { Server } from 'http';
-import cors from 'cors';
-import { join } from 'path';
-import { getProfiles, createProfile } from './profileStore';
+import express from "express";
+import type { Server } from "http";
+import cors from "cors";
+import { createProfile, getProfiles } from "./profileStore";
 
 const app = express();
 const port = Number(process.env.PORT) || 3000;
 
 let server: Server | null = null;
 
-
 app.use(cors());
 app.use(express.json());
 
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok' });
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok" });
 });
 
-app.get('/profiles', async (_req, res) => {
-  const profiles = await getProfiles(userDataPath);
-  res.json(profiles);
-});
-
-app.post('/profiles', async (req, res) => {
-  const { name, role, icon, commands } = req.body ?? {};
-  if (!name || !role) {
-    res.status(400).json({ error: 'name and role required' });
-    return;
-  }
-  const profile = await createProfile(userDataPath, {
-    name,
-    role,
-    icon,
-    commands,
+export function startServer(userDataPath: string): Promise<Server> {
+  app.get("/profiles", async (_req, res) => {
+    const profiles = await getProfiles(userDataPath);
+    res.json(profiles);
   });
-  res.status(201).json(profile);
-});
 
-export function startServer(): Promise<Server> {
+  app.post("/profiles", async (req, res) => {
+    const { name, role, icon, commands } = req.body ?? {};
+    if (!name || !role) {
+      res.status(400).json({ error: "name and role required" });
+      return;
+    }
+    const profile = await createProfile(userDataPath, {
+      name,
+      role,
+      icon,
+      commands,
+    });
+    res.status(201).json(profile);
+  });
+
   return new Promise((resolve, reject) => {
     if (server) {
       resolve(server);
@@ -49,7 +47,7 @@ export function startServer(): Promise<Server> {
         console.log(`Server listening on http://localhost:${port}`);
         resolve(server!);
       })
-      .on('error', (err) => {
+      .on("error", (err) => {
         reject(err);
       });
   });
@@ -67,7 +65,7 @@ export function stopServer(): Promise<void> {
         reject(err);
         return;
       }
-      console.log('Server stopped');
+      console.log("Server stopped");
       server = null;
       resolve();
     });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,12 +1,45 @@
 import express from 'express';
+import cors from 'cors';
+import { join } from 'path';
+import { getProfiles, createProfile } from './profileStore';
 
-const app = express();
-const port = process.env.PORT || 3000;
+export function startServer(userDataPath: string) {
+  const app = express();
+  const port = process.env.PORT || 3000;
 
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok' });
-});
+  app.use(cors());
+  app.use(express.json());
 
-app.listen(port, () => {
-  console.log(`Server listening on http://localhost:${port}`);
-});
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  app.get('/profiles', async (_req, res) => {
+    const profiles = await getProfiles(userDataPath);
+    res.json(profiles);
+  });
+
+  app.post('/profiles', async (req, res) => {
+    const { name, role, icon, commands } = req.body ?? {};
+    if (!name || !role) {
+      res.status(400).json({ error: 'name and role required' });
+      return;
+    }
+    const profile = await createProfile(userDataPath, {
+      name,
+      role,
+      icon,
+      commands,
+    });
+    res.status(201).json(profile);
+  });
+
+  app.listen(port, () => {
+    console.log(`Server listening on http://localhost:${port}`);
+  });
+}
+
+if (require.main === module) {
+  const dataPath = process.env.USER_DATA_PATH || join(process.cwd(), 'data');
+  startServer(dataPath);
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow } from 'electron';
-import './index';
+import { startServer } from './index';
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -14,6 +14,8 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  const dataPath = app.getPath('userData');
+  startServer(dataPath);
   createWindow();
 
   app.on('activate', () => {

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "express": "^5.1.0"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
     "@types/node": "^20.12.5",
     "@typescript-eslint/eslint-plugin": "^8.36.0",

--- a/server/package.json
+++ b/server/package.json
@@ -11,14 +11,15 @@
     "lint": "eslint . --config .eslintrc.cjs"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^5.1.0"
   },
   "devDependencies": {
-    "electron": "^30.5.1",
-    "typescript": "^5.8.3",
-    "@types/node": "^20.12.5",
     "@types/express": "^4.17.21",
+    "@types/node": "^20.12.5",
+    "@typescript-eslint/eslint-plugin": "^8.36.0",
     "@typescript-eslint/parser": "^8.36.0",
-    "@typescript-eslint/eslint-plugin": "^8.36.0"
+    "electron": "^30.5.1",
+    "typescript": "^5.8.3"
   }
 }

--- a/server/profileStore.ts
+++ b/server/profileStore.ts
@@ -1,0 +1,48 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+
+export interface Profile {
+  id: string;
+  name: string;
+  role: string;
+  icon?: string;
+  commands?: string[];
+}
+
+function filePath(dir: string) {
+  return join(dir, 'profiles.json');
+}
+
+async function readProfiles(dir: string): Promise<Profile[]> {
+  try {
+    const data = await fs.readFile(filePath(dir), 'utf-8');
+    return JSON.parse(data) as Profile[];
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+}
+
+async function writeProfiles(dir: string, profiles: Profile[]) {
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(filePath(dir), JSON.stringify(profiles, null, 2));
+}
+
+export async function getProfiles(dir: string): Promise<Profile[]> {
+  return readProfiles(dir);
+}
+
+export async function createProfile(
+  dir: string,
+  profile: Omit<Profile, 'id'>,
+): Promise<Profile> {
+  const profiles = await readProfiles(dir);
+  const newProfile: Profile = { id: randomUUID(), ...profile };
+  profiles.push(newProfile);
+  await writeProfiles(dir, profiles);
+  return newProfile;
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "dist",
     "skipLibCheck": true
   },
-  "include": ["index.ts", "main.ts"]
+  "include": ["index.ts", "main.ts", "profileStore.ts"]
 }


### PR DESCRIPTION
## 요약
- 홈 화면에서 프로필 조회 및 생성 기능 구현
- 서버에 프로필 API(`/profiles`) 추가
- Electron 앱에서 사용자 데이터 경로를 이용해 JSON 파일로 저장
- `cors` 설치 및 서버 구성 갱신

## 테스트 결과
- `npm run lint` 실행: 경고 1건
- `npm test -w server` 실행: "No tests"

------
https://chatgpt.com/codex/tasks/task_e_687280ac43dc8330876b10360ae002d0