### PR TITLE
server/index 리팩토링

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,7 @@ app.get("/health", (_req, res) => {
   res.json({ status: "ok" });
 });
 
-export function startServer(userDataPath: string): Promise<Server> {
+function setupProfileRoutes(userDataPath: string) {
   app.get("/profiles", async (_req, res) => {
     const profiles = await getProfiles(userDataPath);
     res.json(profiles);
@@ -35,6 +35,12 @@ export function startServer(userDataPath: string): Promise<Server> {
     });
     res.status(201).json(profile);
   });
+}
+
+export function startServer(userDataPath: string): Promise<Server> {
+  if (!server) {
+    setupProfileRoutes(userDataPath);
+  }
 
   return new Promise((resolve, reject) => {
     if (server) {


### PR DESCRIPTION
## 요약
- 서버 라우트 설정 함수를 분리하여 `index.ts` 구조를 단순화했습니다.

## 테스트
- `npm run lint`
- `npm test -w server`


------
https://chatgpt.com/codex/tasks/task_e_68728ac087188330904a4d38c24ae068