### PR TITLE
서버 API 라우트 분리

### DIFF
--- a/server/routes/healthRoutes.ts
+++ b/server/routes/healthRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+export function createHealthRoutes() {
+  const router = Router();
+  router.get("/", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+  return router;
+}

--- a/server/routes/profileRoutes.ts
+++ b/server/routes/profileRoutes.ts
@@ -1,0 +1,28 @@
+import { Router } from "express";
+import { createProfile, getProfiles } from "../profileStore";
+
+export function createProfileRoutes(userDataPath: string) {
+  const router = Router();
+
+  router.get("/", async (_req, res) => {
+    const profiles = await getProfiles(userDataPath);
+    res.json(profiles);
+  });
+
+  router.post("/", async (req, res) => {
+    const { name, role, icon, commands } = req.body ?? {};
+    if (!name || !role) {
+      res.status(400).json({ error: "name and role required" });
+      return;
+    }
+    const profile = await createProfile(userDataPath, {
+      name,
+      role,
+      icon,
+      commands,
+    });
+    res.status(201).json(profile);
+  });
+
+  return router;
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "dist",
     "skipLibCheck": true
   },
-  "include": ["index.ts", "main.ts", "profileStore.ts"]
+  "include": ["index.ts", "main.ts", "profileStore.ts", "routes/**/*.ts"]
 }


### PR DESCRIPTION
## 변경 내용
- 프로필과 헬스 체크 API를 `routes` 디렉터리로 분리하여 도메인별 라우트 모듈을 추가했습니다.
- `server/index.ts`에서 새 라우트를 불러와 등록하도록 수정했습니다.
- `tsconfig.json`에 `routes` 경로를 포함시켰습니다.

## 테스트
- `npm run lint`
- `npm test` (서버 패키지)


------
https://chatgpt.com/codex/tasks/task_e_6873209621348330a781215568337443