### PR TITLE
Fix TS2339 by including vite env types

### DIFF
--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -28,5 +28,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["app", ".react-router/types"]
+  "include": ["app", ".react-router/types", "vite-env.d.ts"]
 }


### PR DESCRIPTION
## Summary
- tsconfig에서 `vite-env.d.ts`를 include 하여 `import.meta.env` 타입 오류 해결

## Testing
- `npm run lint` (실패: 스크립트 정의 안 됨)
- `npm test` (실패: 스크립트 정의 안 됨)


------
https://chatgpt.com/codex/tasks/task_e_6873289a9c448330af1062297b5ce2d2